### PR TITLE
Use system provided short month labels

### DIFF
--- a/Sources/AxisContribution/Extentions/Date+Extensions.swift
+++ b/Sources/AxisContribution/Extentions/Date+Extensions.swift
@@ -99,8 +99,8 @@ extension Date {
     }
     
     var monthTitle: String {
-        let monthTitles = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
         let calendar = Calendar.current
+        let monthTitles = calendar.shortMonthSymbols
         let components = calendar.dateComponents([.month], from: self)
         let month = components.month
         return monthTitles[month! - 1]


### PR DESCRIPTION
Since there is a handy API that does that same, we don't have to manually specify the strings. Plus, this API is locale-aware.

The month labels still look OK:
<img src="https://user-images.githubusercontent.com/2663719/221383021-f4fe6b10-c260-40cd-a1bb-c24a87861a57.png" width=400 />

The Month labels for a different locale (`zh-CN` in this case) look fine as well:
<img src="https://user-images.githubusercontent.com/2663719/221383043-40a5b205-5845-4054-9edd-b4127d7f81b6.png" width=400 />

